### PR TITLE
Audio Core: Complete Device Switching

### DIFF
--- a/src/audio_core/sdl2_sink.cpp
+++ b/src/audio_core/sdl2_sink.cpp
@@ -56,17 +56,17 @@ SDL2Sink::SDL2Sink() : impl(std::make_unique<Impl>()) {
     if (device_count < 1 ||
         Settings::values.audio_device_id == "auto" ||
         Settings::values.audio_device_id == "") {
-        impl->audio_device_id = SDL_OpenAudioDevice(nullptr, false, &desired_audiospec, &obtained_audiospec, 0);
+        impl->audio_device_id = SDL_OpenAudioDevice(nullptr, false, &desired_audiospec, &obtained_audiospec, SDL_AUDIO_ALLOW_ANY_CHANGE);
         if (impl->audio_device_id <= 0) {
-            LOG_CRITICAL(Audio_Sink, "SDL_OpenAudioDevice failed");
+            LOG_CRITICAL(Audio_Sink, "SDL_OpenAudioDevice failed with code %d for device \"auto\"", impl->audio_device_id);
             return;
         }
     }
     else
     {
-        impl->audio_device_id = SDL_OpenAudioDevice(device_map[device_id].c_str(), false, &desired_audiospec, &obtained_audiospec, 0);
+        impl->audio_device_id = SDL_OpenAudioDevice(Settings::values.audio_device_id.c_str(), false, &desired_audiospec, &obtained_audiospec, SDL_AUDIO_ALLOW_ANY_CHANGE);
         if (impl->audio_device_id <= 0) {
-            LOG_CRITICAL(Audio_Sink, "SDL_OpenAudioDevice failed");
+            LOG_CRITICAL(Audio_Sink, "SDL_OpenAudioDevice failed with code %d for device \"%s\"", impl->audio_device_id, Settings::values.audio_device_id.c_str());
             return;
         }
     }

--- a/src/audio_core/sdl2_sink.h
+++ b/src/audio_core/sdl2_sink.h
@@ -26,6 +26,7 @@ public:
     std::map<int, std::string>* GetDeviceMap();
     void SetDevice(int _device_id);
 
+
 private:
     struct Impl;
     std::unique_ptr<Impl> impl;
@@ -33,6 +34,5 @@ private:
     std::map<int, std::string> device_map;
 };
 
-extern const std::map<int, std::string> g_device_map;
 
 } // namespace AudioCore

--- a/src/audio_core/sink_details.cpp
+++ b/src/audio_core/sink_details.cpp
@@ -22,4 +22,11 @@ const std::vector<SinkDetails> g_sink_details = {
     { "null", []() { return std::make_unique<NullSink>(); } },
 };
 
+#ifdef HAVE_SDL2
+SDL2Sink sink;
+const std::map<int, std::string> g_device_map = *sink.GetDeviceMap();
+#else
+const std::map<int, std::string> g_device_map = { {0, "null"} };
+#endif
+
 } // namespace AudioCore

--- a/src/audio_core/sink_details.h
+++ b/src/audio_core/sink_details.h
@@ -7,6 +7,7 @@
 #include <functional>
 #include <memory>
 #include <vector>
+#include <map>
 
 namespace AudioCore {
 
@@ -23,5 +24,6 @@ struct SinkDetails {
 };
 
 extern const std::vector<SinkDetails> g_sink_details;
+extern const std::map<int, std::string> g_device_map;
 
 } // namespace AudioCore

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -66,6 +66,10 @@ bg_green =
 # auto (default): Auto-select, null: No audio output, sdl2: SDL2 (if available)
 output_engine =
 
+# Which audio device to use.
+# auto (default): Auto-select
+output_device =
+
 [Data Storage]
 # Whether to create a virtual SD card.
 # 1 (default): Yes, 0: No

--- a/src/citra_qt/config.cpp
+++ b/src/citra_qt/config.cpp
@@ -59,6 +59,7 @@ void Config::ReadValues() {
 
     qt_config->beginGroup("Audio");
     Settings::values.sink_id = qt_config->value("output_engine", "auto").toString().toStdString();
+    Settings::values.audio_device_id = qt_config->value("output_device", "auto").toString().toStdString();
     qt_config->endGroup();
 
     qt_config->beginGroup("Data Storage");
@@ -151,6 +152,7 @@ void Config::SaveValues() {
 
     qt_config->beginGroup("Audio");
     qt_config->setValue("output_engine", QString::fromStdString(Settings::values.sink_id));
+    qt_config->setValue("output_device", QString::fromStdString(Settings::values.audio_device_id));
     qt_config->endGroup();
 
     qt_config->beginGroup("Data Storage");

--- a/src/citra_qt/configure_audio.cpp
+++ b/src/citra_qt/configure_audio.cpp
@@ -23,9 +23,9 @@ ConfigureAudio::ConfigureAudio(QWidget* parent) :
 
     ui->audio_device_combo_box->clear();
     ui->audio_device_combo_box->addItem("auto");
-    //for (const auto& device : AudioCore:) {
-    //    ui->audio_device_combo_box->addItem(device.second.c_str());
-    //}
+    for (const auto& device : AudioCore::g_device_map) {
+        ui->audio_device_combo_box->addItem(device.second.c_str());
+    }
 
     this->setConfiguration();
 }
@@ -51,7 +51,7 @@ void ConfigureAudio::setConfiguration() {
             break;
         }
     }
-    ui->audio_device_combo_box->setCurrentIndex(new_sink_index);
+    ui->audio_device_combo_box->setCurrentIndex(new_device_index);
 }
 
 void ConfigureAudio::applyConfiguration() {


### PR DESCRIPTION
Complete the device switching implementation by allowing the output device to be loaded, changed and saved through the configurations menu.